### PR TITLE
Suppression des deprecated flask.ext.* imports pour flask_*

### DIFF
--- a/src/mapif.py
+++ b/src/mapif.py
@@ -19,10 +19,10 @@ from flask import abort
 from flask import render_template
 from flask import flash
 from flask import escape
-from flask.ext.responses import json_response
-from flask.ext.responses import xml_response
-from flask.ext.responses import auto_response
-from flask.ext.cors import CORS
+from flask_responses import json_response
+from flask_responses import xml_response
+from flask_responses import auto_response
+from flask_cors import CORS
 from src.utils import db
 from src.utils.response import Response
 from src.utils import validator

--- a/src/utils/wrappers.py
+++ b/src/utils/wrappers.py
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------------------
 
 import time
-from flask.ext.responses import json_response
+from flask_responses import json_response
 from flask import session
 from functools import wraps
 from src.utils.response import Response


### PR DESCRIPTION
Salut,

Ça nécessitera éventuellement une mise à jour des _requirements_ du serveur en production

David